### PR TITLE
 Refactor Python 3.12 install scripts to use shared distro helper

### DIFF
--- a/examples/Python3.12/Granite-with-pytorch-example/install_test_example.sh
+++ b/examples/Python3.12/Granite-with-pytorch-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")
@@ -44,12 +33,10 @@ case $DISTRO in
         ;;
 esac
 
-
 python3.12 -m venv venv
 source venv/bin/activate
 
 pip install --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
-
 
 echo "USING Granite 3"
 echo "Running: granite3-example.py"

--- a/examples/Python3.12/ML-DS-example/install_test_example.sh
+++ b/examples/Python3.12/ML-DS-example/install_test_example.sh
@@ -1,40 +1,10 @@
 #!/bin/bash
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
-
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")
@@ -67,8 +37,6 @@ case $DISTRO in
         exit 1
         ;;
 esac
-
-
 
 python3.12 -m venv .venv
 source .venv/bin/activate

--- a/examples/Python3.12/_common/distro_utils.sh
+++ b/examples/Python3.12/_common/distro_utils.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+detect_distro() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        echo "$ID"
+    elif [ -f /etc/redhat-release ]; then
+        echo "rhel"
+    elif [ -f /etc/debian_version ]; then
+        echo "debian"
+    else
+        echo "unknown"
+    fi
+}
+
+init_distro_context() {
+    DISTRO=$(detect_distro)
+    echo "Detected distribution: $DISTRO"
+    echo "Installing prerequisites..."
+}

--- a/examples/Python3.12/azure-example/install_test_example.sh
+++ b/examples/Python3.12/azure-example/install_test_example.sh
@@ -1,24 +1,9 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
 
 # -------------------------------
 # Install system dependencies
@@ -47,8 +32,6 @@ case $DISTRO in
         ;;
 esac
 
-
-
 python3.12 -m venv .venv
 source .venv/bin/activate
 
@@ -63,4 +46,3 @@ python3.12 azure_example.py
 echo "\n ==== Running tests ==== \n"
 
 python3.12 sub-test1.py
-

--- a/examples/Python3.12/bcrypt-example/install_test_example.sh
+++ b/examples/Python3.12/bcrypt-example/install_test_example.sh
@@ -1,24 +1,9 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
 
 # -------------------------------
 # Install system dependencies
@@ -47,9 +32,6 @@ case $DISTRO in
         ;;
 esac
 
-
-
-
 python3.12 -m venv .venv
 source .venv/bin/activate
 
@@ -64,4 +46,3 @@ python3.12 bcrypt_example.py
 echo "\n ==== Running tests ==== \n"
 
 python3.12 sub-test1.py
-

--- a/examples/Python3.12/black-example/install_test_example.sh
+++ b/examples/Python3.12/black-example/install_test_example.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
+init_distro_context
+
 
 # -------------------------------
 # Install system dependencies
@@ -45,8 +31,6 @@ case $DISTRO in
         exit 1
         ;;
 esac
-
-
 
 python3.12 -m venv .venv
 source .venv/bin/activate

--- a/examples/Python3.12/dask_example/install_test_example.sh
+++ b/examples/Python3.12/dask_example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/langchain-example/install_test_example.sh
+++ b/examples/Python3.12/langchain-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/lightgbm-pyarrow-example/install_test_example.sh
+++ b/examples/Python3.12/lightgbm-pyarrow-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/matplotlib-imageio-example/install_test_example.sh
+++ b/examples/Python3.12/matplotlib-imageio-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")
@@ -62,4 +51,3 @@ python3.12 sub-test2.py
 
 printf "\nRunning sub-test3.py\n"
 python3.12 sub-test3.py
-

--- a/examples/Python3.12/nbformat-nbconvert-example/install_test_example.sh
+++ b/examples/Python3.12/nbformat-nbconvert-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/ollama-example/install_test_example.sh
+++ b/examples/Python3.12/ollama-example/install_test_example.sh
@@ -1,20 +1,9 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/onnx_example/install_test_example.sh
+++ b/examples/Python3.12/onnx_example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/pyav-example/install_test_example.sh
+++ b/examples/Python3.12/pyav-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")
@@ -45,7 +34,6 @@ python3.12 -m venv .venv
 source .venv/bin/activate
 
 pip install --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
-
 
 # Run Python scripts
 printf "\nRunning av-example.py\n"

--- a/examples/Python3.12/pytorch-example/install_test_example.sh
+++ b/examples/Python3.12/pytorch-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/rake-nltk-example/install_test_example.sh
+++ b/examples/Python3.12/rake-nltk-example/install_test_example.sh
@@ -1,24 +1,9 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
 
 # -------------------------------
 # Install system dependencies
@@ -47,9 +32,6 @@ case $DISTRO in
         ;;
 esac
 
-
-
-
 python3.12 -m venv .venv
 source .venv/bin/activate
 
@@ -64,4 +46,3 @@ python3.12 bcrypt_example.py
 echo "\n ==== Running tests ==== \n"
 
 python3.12 sub-test1.py
-

--- a/examples/Python3.12/ray-example/install_test_example.sh
+++ b/examples/Python3.12/ray-example/install_test_example.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
+init_distro_context
+
 
 # -------------------------------
 # Install system dependencies
@@ -45,8 +31,6 @@ case $DISTRO in
         exit 1
         ;;
 esac
-
-
 
 python3.12 -m venv .venv
 source .venv/bin/activate

--- a/examples/Python3.12/rtree-example/install_test_example.sh
+++ b/examples/Python3.12/rtree-example/install_test_example.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
+init_distro_context
+
 
 # -------------------------------
 # Install system dependencies
@@ -45,8 +31,6 @@ case $DISTRO in
         exit 1
         ;;
 esac
-
-
 
 python3.12 -m venv .venv
 source .venv/bin/activate

--- a/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/install_test_example.sh
+++ b/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")
@@ -61,7 +50,6 @@ pip install --prefer-binary --extra-index-url=https://wheels.developerfirst.ibm.
 
 # Upgrade pip
 pip install --upgrade pip
-
 
 # Run scripts
 echo -e "\nRunning scikitlearn_ibmcossdk_jwt_example.py"

--- a/examples/Python3.12/seaborn-example/install_test_example.sh
+++ b/examples/Python3.12/seaborn-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/torchvision-torchaudio-example/install_test_example.sh
+++ b/examples/Python3.12/torchvision-torchaudio-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")
@@ -53,4 +42,3 @@ echo "\n ==== Running tests ==== \n"
 
 python sub-test1.py
 python sub-test2.py
-

--- a/examples/Python3.12/treesitter-example/install_test_example.sh
+++ b/examples/Python3.12/treesitter-example/install_test_example.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
+init_distro_context
+
 
 # -------------------------------
 # Install system dependencies
@@ -45,8 +31,6 @@ case $DISTRO in
         exit 1
         ;;
 esac
-
-
 
 python3.12 -m venv .venv
 source .venv/bin/activate

--- a/examples/Python3.12/vllm-example/install_test_example.sh
+++ b/examples/Python3.12/vllm-example/install_test_example.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
 
-# Function to detect Linux distribution
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
+init_distro_context
 
 # Install system dependencies based on distribution
-DISTRO=$(detect_distro)
 
 case $DISTRO in
     "fedora"|"rhel"|"centos"|"rocky"|"almalinux")

--- a/examples/Python3.12/xgboost-example/install_test_example.sh
+++ b/examples/Python3.12/xgboost-example/install_test_example.sh
@@ -1,25 +1,11 @@
 #!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/distro_utils.sh"
+
+init_distro_context
+
 set -e
-
-# -------------------------------
-# Function to detect Linux distro
-# -------------------------------
-detect_distro() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        echo $ID
-    elif [ -f /etc/redhat-release ]; then
-        echo "rhel"
-    elif [ -f /etc/debian_version ]; then
-        echo "debian"
-    else
-        echo "unknown"
-    fi
-}
-
-DISTRO=$(detect_distro)
-echo "Detected distribution: $DISTRO"
-echo "Installing prerequisites..."
 
 # -------------------------------
 # Install system dependencies


### PR DESCRIPTION
Summary
Add shared distro helper at examples/Python3.12/_common/distro_utils.sh.
Remove duplicated detect_distro logic from all Python 3.12 install_test_example.sh scripts.
Standardize script initialization by sourcing the shared helper and calling init_distro_context.
Preserve existing package-install case logic in each example script.
Clean up duplicated distro detection in examples/Python3.12/ML-DS-example/install_test_example.sh.

Why
Reduces repeated shell logic across 23 scripts.
Makes distro detection behavior consistent for all Python 3.12 examples.
Simplifies future maintenance (single place to update distro detection).

What changed
New shared file:
examples/Python3.12/_common/distro_utils.sh
detect_distro()
init_distro_context() (sets DISTRO and prints setup context)
Updated all examples/Python3.12/*/install_test_example.sh scripts to:
compute SCRIPT_DIR
source "$SCRIPT_DIR/../_common/distro_utils.sh"
call init_distro_context

Validation
Ran syntax checks:
bash -n examples/Python3.12/_common/distro_utils.sh
bash -n for each examples/Python3.12/*/install_test_example.sh
Result: all checks pass.

Notes
I understand this change may not be helpful based on the nature of how you intend to use these scripts. For example, if you expect the script to work without access to that python3.12 directory, this change is needless. If on the other hand, we can assume that the script will be ran from within the python3.12 directory, this would reduce duplicaiton.

I'm also able to make these same changes in python3.11 and python3.10 if necessary.

Would love to hear feedback.