### PR TITLE
Refactor python venv

### DIFF
--- a/examples/Python3.12/Granite-with-pytorch-example/install_test_example.sh
+++ b/examples/Python3.12/Granite-with-pytorch-example/install_test_example.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/python_env.sh"
+
 # Function to detect Linux distribution
 detect_distro() {
     if [ -f /etc/os-release ]; then
@@ -45,10 +48,7 @@ case $DISTRO in
 esac
 
 
-python3.12 -m venv venv
-source venv/bin/activate
-
-pip install --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
+setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
 
 
 echo "USING Granite 3"

--- a/examples/Python3.12/Granite-with-pytorch-example/install_test_example.sh
+++ b/examples/Python3.12/Granite-with-pytorch-example/install_test_example.sh
@@ -48,7 +48,7 @@ case $DISTRO in
 esac
 
 
-setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
+setup_python312_venv requirements.txt --no-cache --prefer-binary
 
 
 echo "USING Granite 3"

--- a/examples/Python3.12/_common/python_env.sh
+++ b/examples/Python3.12/_common/python_env.sh
@@ -2,6 +2,7 @@
 
 setup_python312_venv() {
     local requirements_file="${1:-requirements.txt}"
+    local extra_index_url="${SETUP_PYTHON312_EXTRA_INDEX_URL:-https://wheels.developerfirst.ibm.com/ppc64le/linux}"
     shift || true
 
     python3.12 -m venv venv
@@ -12,5 +13,5 @@ setup_python312_venv() {
         pip install --upgrade pip
     fi
 
-    pip install "$@" -r "$requirements_file"
+    pip install "$@" --extra-index-url "$extra_index_url" -r "$requirements_file"
 }

--- a/examples/Python3.12/_common/python_env.sh
+++ b/examples/Python3.12/_common/python_env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+setup_python312_venv() {
+    local requirements_file="${1:-requirements.txt}"
+    shift || true
+
+    python3.12 -m venv venv
+    # shellcheck source=/dev/null
+    source venv/bin/activate
+
+    if [ "${SETUP_PYTHON312_UPGRADE_PIP:-0}" = "1" ]; then
+        pip install --upgrade pip
+    fi
+
+    pip install "$@" -r "$requirements_file"
+}

--- a/examples/Python3.12/ollama-example/install_test_example.sh
+++ b/examples/Python3.12/ollama-example/install_test_example.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/python_env.sh"
+
 # Function to detect Linux distribution
 detect_distro() {
     if [ -f /etc/os-release ]; then
@@ -42,13 +45,11 @@ esac
 # ----------------------------------------
 # Python virtual environment
 # ----------------------------------------
-python3.12 -m venv venv
-source venv/bin/activate
-pip install --upgrade pip
-
-pip install --no-cache --prefer-binary \
-    --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
-    -r requirements.txt
+SETUP_PYTHON312_UPGRADE_PIP=1 setup_python312_venv \
+    requirements.txt \
+    --no-cache \
+    --prefer-binary \
+    --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
 
 # ----------------------------------------
 # Add ollama binary to PATH

--- a/examples/Python3.12/ollama-example/install_test_example.sh
+++ b/examples/Python3.12/ollama-example/install_test_example.sh
@@ -48,8 +48,7 @@ esac
 SETUP_PYTHON312_UPGRADE_PIP=1 setup_python312_venv \
     requirements.txt \
     --no-cache \
-    --prefer-binary \
-    --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
+    --prefer-binary
 
 # ----------------------------------------
 # Add ollama binary to PATH

--- a/examples/Python3.12/onnx_example/install_test_example.sh
+++ b/examples/Python3.12/onnx_example/install_test_example.sh
@@ -45,7 +45,7 @@ case $DISTRO in
         ;;
 esac
 
-setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
+setup_python312_venv requirements.txt --no-cache --prefer-binary
 
 WORKDIR=$(pwd)
 

--- a/examples/Python3.12/onnx_example/install_test_example.sh
+++ b/examples/Python3.12/onnx_example/install_test_example.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/python_env.sh"
+
 # Function to detect Linux distribution
 detect_distro() {
     if [ -f /etc/os-release ]; then
@@ -42,10 +45,7 @@ case $DISTRO in
         ;;
 esac
 
-python3.12 -m venv venv
-source venv/bin/activate
-
-python3.12 -m pip install --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
+setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
 
 WORKDIR=$(pwd)
 

--- a/examples/Python3.12/pytorch-example/install_test_example.sh
+++ b/examples/Python3.12/pytorch-example/install_test_example.sh
@@ -44,7 +44,7 @@ case $DISTRO in
         ;;
 esac
 
-setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
+setup_python312_venv requirements.txt --no-cache --prefer-binary
 
 python pytorch_example.py
 

--- a/examples/Python3.12/pytorch-example/install_test_example.sh
+++ b/examples/Python3.12/pytorch-example/install_test_example.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/python_env.sh"
+
 # Function to detect Linux distribution
 detect_distro() {
     if [ -f /etc/os-release ]; then
@@ -41,10 +44,7 @@ case $DISTRO in
         ;;
 esac
 
-python3.12 -m venv venv
-source venv/bin/activate
-
-pip install --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
+setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
 
 python pytorch_example.py
 

--- a/examples/Python3.12/torchvision-torchaudio-example/install_test_example.sh
+++ b/examples/Python3.12/torchvision-torchaudio-example/install_test_example.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/python_env.sh"
+
 # Function to detect Linux distribution
 detect_distro() {
     if [ -f /etc/os-release ]; then
@@ -41,10 +44,7 @@ case $DISTRO in
         ;;
 esac
 
-python3.12 -m venv venv
-source venv/bin/activate
-
-pip install --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
+setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
 
 python torchaudio_example.py
 python torchvision_example.py

--- a/examples/Python3.12/torchvision-torchaudio-example/install_test_example.sh
+++ b/examples/Python3.12/torchvision-torchaudio-example/install_test_example.sh
@@ -44,7 +44,7 @@ case $DISTRO in
         ;;
 esac
 
-setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
+setup_python312_venv requirements.txt --no-cache --prefer-binary
 
 python torchaudio_example.py
 python torchvision_example.py

--- a/examples/Python3.12/vllm-example/install_test_example.sh
+++ b/examples/Python3.12/vllm-example/install_test_example.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/python_env.sh"
+
 # Function to detect Linux distribution
 detect_distro() {
     if [ -f /etc/os-release ]; then
@@ -55,12 +58,9 @@ case $DISTRO in
         ;;
 esac
 
-python3.12 -m venv venv
-source venv/bin/activate
-
 export VLLM_USE_CUSTOM_OPS=0
 
-pip install --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
+setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
 
 python vllm_example.py
 

--- a/examples/Python3.12/vllm-example/install_test_example.sh
+++ b/examples/Python3.12/vllm-example/install_test_example.sh
@@ -60,7 +60,7 @@ esac
 
 export VLLM_USE_CUSTOM_OPS=0
 
-setup_python312_venv requirements.txt --no-cache --prefer-binary --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux
+setup_python312_venv requirements.txt --no-cache --prefer-binary
 
 python vllm_example.py
 


### PR DESCRIPTION
## Summary
Add a shared Python environment helper at `examples/Python3.12/_common/python_env.sh` and update Python 3.12 install scripts to use it for virtualenv setup and requirements installation. This could work well with PR #71 to avoid duplication and centralize common functions in examples directory.

## Why
Reduces duplicated shell setup logic across examples and centralizes Python 3.12 environment bootstrapping in one reusable location.

## What changed
- Added shared helper:
  - `examples/Python3.12/_common/python_env.sh`
  - `setup_python312_venv()` now creates `venv`, activates it, optionally upgrades `pip`, and installs requirements with passed-through flags.
- Updated install scripts to source and call the helper:
  - `examples/Python3.12/ollama-example/install_test_example.sh`
  - `examples/Python3.12/pytorch-example/install_test_example.sh`
  - `examples/Python3.12/Granite-with-pytorch-example/install_test_example.sh`
  - `examples/Python3.12/onnx_example/install_test_example.sh`
  - `examples/Python3.12/torchvision-torchaudio-example/install_test_example.sh`
  - `examples/Python3.12/vllm-example/install_test_example.sh`
- Preserved existing script-specific install flags and behavior.
- Kept `ollama-example` `pip` upgrade behavior by setting `SETUP_PYTHON312_UPGRADE_PIP=1` on the helper call.

## Validation
- `bash -n examples/Python3.12/_common/python_env.sh`
- `bash -n` run for each updated `examples/Python3.12/*/install_test_example.sh`
- Result: all syntax checks pass.

## Notes
This refactor assumes scripts execute within their example directories (existing behavior), so relative sourcing of `../_common/python_env.sh` is stable and intentional.