### PR TITLE
Updated requirements.txt for Python 3.11 &3.12 as per v5 set

### DIFF
--- a/examples/Python3.11/catboost-example/requirements.txt
+++ b/examples/Python3.11/catboost-example/requirements.txt
@@ -9,7 +9,7 @@ matplotlib==3.10.8+ppc64le1
 narwhals==2.20.0
 numpy==1.26.4+ppc64le1
 packaging==26.1
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 plotly==6.7.0
 pyparsing==3.3.1+ppc64le1

--- a/examples/Python3.11/lightgbm-pyarrow-example/requirements.txt
+++ b/examples/Python3.11/lightgbm-pyarrow-example/requirements.txt
@@ -7,7 +7,7 @@ lightgbm==4.6.0+ppc64le1
 matplotlib==3.10.8+ppc64le1
 numpy==2.4.4+ppc64le1
 packaging==25.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 pyarrow==20.0.0+ppc64le2
 pyparsing==3.3.1+ppc64le1

--- a/examples/Python3.11/onnx_example/requirements.txt
+++ b/examples/Python3.11/onnx_example/requirements.txt
@@ -7,7 +7,7 @@ idna==3.10
 joblib==1.5.2
 mpmath==1.3.0+ppc64le1
 numpy==2.0.2+ppc64le1
-onnx==1.19.0+ppc64le2
+onnx==1.17.0+ppc64le1
 onnxconverter-common==1.14.0+ppc64le1
 onnxmltools==1.13.0+ppc64le1
 onnxruntime==1.25.1+ppc64le1

--- a/examples/Python3.11/onnx_example/requirements.txt
+++ b/examples/Python3.11/onnx_example/requirements.txt
@@ -7,10 +7,10 @@ idna==3.10
 joblib==1.5.2
 mpmath==1.3.0+ppc64le1
 numpy==2.0.2+ppc64le1
-onnx==1.17.0+ppc64le1
+onnx==1.19.0+ppc64le2
 onnxconverter-common==1.14.0+ppc64le1
 onnxmltools==1.13.0+ppc64le1
-onnxruntime==1.23.2+ppc64le2
+onnxruntime==1.25.1+ppc64le1
 packaging==25.0
 requests==2.32.5
 scikit-learn==1.6.1+ppc64le1

--- a/examples/Python3.11/pytorch-example/requirements.txt
+++ b/examples/Python3.11/pytorch-example/requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==3.0.2+ppc64le2
 mpmath==1.3.0+ppc64le1
 networkx==3.5
 numpy==2.4.4+ppc64le1
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 psutil==7.2.2+ppc64le1
 python-dateutil==2.9.0.post0
 pytz==2025.2

--- a/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -25,10 +25,10 @@ numexpr==2.14.1+ppc64le1
 numpy==2.4.4+ppc64le1
 onnx==1.20.1+ppc64le1
 onnxconverter-common==1.12.1
-onnxruntime==1.23.2+ppc64le2
+onnxruntime==1.25.1+ppc64le1
 ormsgpack==1.12.0+ppc64le1
 packaging==25.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 primp==0.15.0+ppc64le1
 protobuf==4.25.3+ppc64le1
@@ -51,7 +51,7 @@ threadpoolctl==3.6.0
 tornado==6.5.2+ppc64le1
 typing_extensions==4.15.0
 tzdata==2025.2+ppc64le1
-ujson==5.12.0+ppc64le1
+ujson==5.12.1+ppc64le1
 urllib3==2.4.0
 uvloop==0.22.1+ppc64le1
 xattr==1.3.0+ppc64le1

--- a/examples/Python3.11/seaborn-example/requirements.txt
+++ b/examples/Python3.11/seaborn-example/requirements.txt
@@ -5,7 +5,7 @@ kiwisolver==1.4.4+ppc64le1
 matplotlib==3.10.8+ppc64le1
 numpy==2.4.4+ppc64le1
 packaging==26.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 pyparsing==3.3.1+ppc64le1
 python-dateutil==2.9.0.post0

--- a/examples/Python3.11/vllm-example/requirements.txt
+++ b/examples/Python3.11/vllm-example/requirements.txt
@@ -117,7 +117,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.42.0
-vllm==0.18.1+cpuppc64le1
+vllm==0.21.0+cpuppc64le1
 watchfiles==0.21.0+ppc64le1
 websockets==16.0
 wrapt==2.1.2

--- a/examples/Python3.11/vllm-example/requirements.txt
+++ b/examples/Python3.11/vllm-example/requirements.txt
@@ -64,7 +64,7 @@ networkx==3.6.1
 ninja==1.13.0
 numba==0.61.2+ppc64le3
 numpy==2.2.6+ppc64le1
-openai==2.0.0
+openai==1.99.1
 openai-harmony==0.0.8+ppc64le1
 opencv-python-headless==4.13.0.92+ppc64le1
 outlines_core==0.2.11+ppc64le1
@@ -117,7 +117,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.42.0
-vllm==0.21.0+cpuppc64le1
+vllm==0.18.1+cpuppc64le1
 watchfiles==0.21.0+ppc64le1
 websockets==16.0
 wrapt==2.1.2

--- a/examples/Python3.11/vllm-example/requirements.txt
+++ b/examples/Python3.11/vllm-example/requirements.txt
@@ -88,7 +88,7 @@ pyjwt==2.12.1
 python-dotenv==1.2.2
 python-json-logger==4.0.0
 python-multipart==0.0.22
-pyyaml==6.0.3+ppc64le1
+pyyaml==6.0.3+ppc64le2
 pyzmq==27.1.0+ppc64le1
 referencing==0.37.0
 regex==2024.11.6+ppc64le1

--- a/examples/Python3.11/vllm-example/requirements.txt
+++ b/examples/Python3.11/vllm-example/requirements.txt
@@ -64,7 +64,7 @@ networkx==3.6.1
 ninja==1.13.0
 numba==0.61.2+ppc64le3
 numpy==2.2.6+ppc64le1
-openai==1.99.1
+openai==2.0.0
 openai-harmony==0.0.8+ppc64le1
 opencv-python-headless==4.13.0.92+ppc64le1
 outlines_core==0.2.11+ppc64le1

--- a/examples/Python3.11/xgboost-example/requirements.txt
+++ b/examples/Python3.11/xgboost-example/requirements.txt
@@ -11,7 +11,7 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2+ppc64le2
 numpy==2.4.4+ppc64le1
 packaging==25.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pycparser==2.22
 Pygments==2.19.2+ppc64le1
 python-dateutil==2.9.0.post0

--- a/examples/Python3.12/ML-DS-example/requirements.txt
+++ b/examples/Python3.12/ML-DS-example/requirements.txt
@@ -101,7 +101,7 @@ numba==0.63.1+ppc64le1
 numexpr==2.13.1+ppc64le1
 numpy==2.3.5+ppc64le1
 packaging==26.0
-pandas==2.3.3+ppc64le1
+pandas==3.0.3+ppc64le1
 pandocfilters==1.5.1
 parso==0.8.6
 partd==1.4.1+ppc64le1

--- a/examples/Python3.12/ML-DS-example/requirements.txt
+++ b/examples/Python3.12/ML-DS-example/requirements.txt
@@ -101,7 +101,7 @@ numba==0.63.1+ppc64le1
 numexpr==2.13.1+ppc64le1
 numpy==2.3.5+ppc64le1
 packaging==26.0
-pandas==3.0.3+ppc64le1
+pandas==2.3.3+ppc64le1
 pandocfilters==1.5.1
 parso==0.8.6
 partd==1.4.1+ppc64le1

--- a/examples/Python3.12/catboost-example/requirements.txt
+++ b/examples/Python3.12/catboost-example/requirements.txt
@@ -9,7 +9,7 @@ matplotlib==3.10.8+ppc64le1
 narwhals==2.20.0
 numpy==1.26.4+ppc64le1
 packaging==26.1
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 plotly==6.7.0
 pyparsing==3.3.1+ppc64le1

--- a/examples/Python3.12/lightgbm-pyarrow-example/requirements.txt
+++ b/examples/Python3.12/lightgbm-pyarrow-example/requirements.txt
@@ -7,7 +7,7 @@ lightgbm==4.6.0+ppc64le1
 matplotlib==3.10.8+ppc64le1
 numpy==2.4.4+ppc64le1
 packaging==25.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 pyarrow==21.0.0+ppc64le1
 pyparsing==3.3.1+ppc64le1

--- a/examples/Python3.12/onnx_example/requirements.txt
+++ b/examples/Python3.12/onnx_example/requirements.txt
@@ -7,7 +7,7 @@ idna==3.10
 joblib==1.5.2
 mpmath==1.3.0+ppc64le1
 numpy==2.0.2+ppc64le1
-onnx==1.19.0+ppc64le2
+onnx==1.17.0+ppc64le2
 onnxconverter-common==1.14.0+ppc64le1
 onnxmltools==1.13.0+ppc64le1
 onnxruntime==1.25.1+ppc64le1

--- a/examples/Python3.12/onnx_example/requirements.txt
+++ b/examples/Python3.12/onnx_example/requirements.txt
@@ -7,10 +7,10 @@ idna==3.10
 joblib==1.5.2
 mpmath==1.3.0+ppc64le1
 numpy==2.0.2+ppc64le1
-onnx==1.17.0+ppc64le2
+onnx==1.19.0+ppc64le2
 onnxconverter-common==1.14.0+ppc64le1
 onnxmltools==1.13.0+ppc64le1
-onnxruntime==1.23.2+ppc64le2
+onnxruntime==1.25.1+ppc64le1
 packaging==25.0
 requests==2.32.5
 scikit-learn==1.6.1+ppc64le2

--- a/examples/Python3.12/pytorch-example/requirements.txt
+++ b/examples/Python3.12/pytorch-example/requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==3.0.2+ppc64le2
 mpmath==1.3.0+ppc64le1
 networkx==3.5
 numpy==2.4.4+ppc64le1
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 psutil==7.2.2+ppc64le1
 python-dateutil==2.9.0.post0
 pytz==2025.2

--- a/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -25,10 +25,10 @@ numexpr==2.14.1+ppc64le1
 numpy==2.4.4+ppc64le1
 onnx==1.21.0+ppc64le1
 onnxconverter-common==1.12.1
-onnxruntime==1.23.2+ppc64le2
+onnxruntime==1.25.1+ppc64le1
 ormsgpack==1.12.0+ppc64le1
 packaging==25.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 primp==0.15.0+ppc64le1
 protobuf==4.25.8+ppc64le1
@@ -51,7 +51,7 @@ threadpoolctl==3.6.0
 tornado==6.5.2+ppc64le1
 typing_extensions==4.15.0
 tzdata==2025.2+ppc64le1
-ujson==5.12.0+ppc64le1
+ujson==5.12.1+ppc64le1
 urllib3==2.4.0
 uvloop==0.22.1+ppc64le1
 xattr==1.3.0+ppc64le1

--- a/examples/Python3.12/seaborn-example/requirements.txt
+++ b/examples/Python3.12/seaborn-example/requirements.txt
@@ -5,7 +5,7 @@ kiwisolver==1.4.4+ppc64le1
 matplotlib==3.10.8+ppc64le1
 numpy==2.4.4+ppc64le1
 packaging==26.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
 pyparsing==3.3.1+ppc64le1
 python-dateutil==2.9.0.post0

--- a/examples/Python3.12/vllm-example/requirements.txt
+++ b/examples/Python3.12/vllm-example/requirements.txt
@@ -117,7 +117,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.42.0
-vllm==0.18.1+cpuppc64le1
+vllm==0.21.0+cpuppc64le1
 watchfiles==0.21.0+ppc64le1
 websockets==16.0
 wrapt==2.1.2

--- a/examples/Python3.12/vllm-example/requirements.txt
+++ b/examples/Python3.12/vllm-example/requirements.txt
@@ -64,7 +64,7 @@ networkx==3.6.1
 ninja==1.13.0
 numba==0.61.2+ppc64le3
 numpy==2.2.6+ppc64le1
-openai==2.0.0
+openai==1.99.1
 openai-harmony==0.0.8+ppc64le1
 opencv-python-headless==4.13.0.92+ppc64le1
 outlines_core==0.2.11+ppc64le1
@@ -117,7 +117,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.42.0
-vllm==0.21.0+cpuppc64le1
+vllm==0.18.1+cpuppc64le1
 watchfiles==0.21.0+ppc64le1
 websockets==16.0
 wrapt==2.1.2

--- a/examples/Python3.12/vllm-example/requirements.txt
+++ b/examples/Python3.12/vllm-example/requirements.txt
@@ -88,7 +88,7 @@ pyjwt==2.12.1
 python-dotenv==1.2.2
 python-json-logger==4.0.0
 python-multipart==0.0.22
-pyyaml==6.0.3+ppc64le1
+pyyaml==6.0.3+ppc64le2
 pyzmq==27.1.0+ppc64le1
 referencing==0.37.0
 regex==2024.11.6+ppc64le1

--- a/examples/Python3.12/vllm-example/requirements.txt
+++ b/examples/Python3.12/vllm-example/requirements.txt
@@ -64,7 +64,7 @@ networkx==3.6.1
 ninja==1.13.0
 numba==0.61.2+ppc64le3
 numpy==2.2.6+ppc64le1
-openai==1.99.1
+openai==2.0.0
 openai-harmony==0.0.8+ppc64le1
 opencv-python-headless==4.13.0.92+ppc64le1
 outlines_core==0.2.11+ppc64le1

--- a/examples/Python3.12/xgboost-example/requirements.txt
+++ b/examples/Python3.12/xgboost-example/requirements.txt
@@ -11,7 +11,7 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2+ppc64le2
 numpy==2.4.4+ppc64le1
 packaging==25.0
-pandas==3.0.2+ppc64le1
+pandas==3.0.3+ppc64le1
 pycparser==2.22
 Pygments==2.19.2
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
### Updated requirements.txt for Python 3.11 & Python3.12 as per the v5 set:

- Updated pandas version to latest 3.0.3+ppc64le1 for catboost-example, lightgbm-pyarrow-example, pytorch-example, scikitlearn-ibmcossdk-jwt-example, seaborn-example & xgboost-examples
- Updated onnxruntime version to latest 1.25.1+ppc64le1 for onnx_example & scikitlearn-ibmcossdk-jwt-example
- Updated ujson version to latest 5.12.1+ppc64le1 for scikitlearn-ibmcossdk-jwt-example
- Updated pyyaml version to latest 6.0.3+ppc64le2 for vllm-example
- Note: vllm version hasn't been updated because of this open issue [1769](https://github.ibm.com/ppc64le-automation/python-ecosystem/issues/1769#issuecomment-203262253)