### PR TITLE
Updated requirements.txt for vllm example as per V5 set

### DIFF
--- a/examples/Python3.11/vllm-example/requirements.txt
+++ b/examples/Python3.11/vllm-example/requirements.txt
@@ -16,7 +16,7 @@ cffi==2.0.0+ppc64le1
 charset_normalizer==3.4.6
 click==8.3.1
 cloudpickle==3.1.2+ppc64le1
-compressed-tensors==0.13.0
+compressed-tensors==0.15.0.1
 depyf==0.20.0
 dill==0.4.1+ppc64le1
 diskcache==5.6.3
@@ -55,7 +55,7 @@ loguru==0.7.3
 markdown-it-py==4.0.0
 mcp==1.26.0
 mdurl==0.1.2
-mistral_common==1.10.0
+mistral_common==1.11.3
 model-hosting-container-standards==0.1.14
 mpmath==1.3.0+ppc64le1
 msgspec==0.19.0+ppc64le2
@@ -64,10 +64,10 @@ networkx==3.6.1
 ninja==1.13.0
 numba==0.61.2+ppc64le3
 numpy==2.2.6+ppc64le1
-openai==1.99.1
+openai==2.0.0
 openai-harmony==0.0.8+ppc64le1
 opencv-python-headless==4.13.0.92+ppc64le1
-outlines_core==0.2.11+ppc64le1
+outlines_core==0.2.14+ppc64le1
 packaging==26.0
 partial-json-parser==0.2.1.1.post7
 prometheus-fastapi-instrumentator==7.1.0
@@ -109,7 +109,7 @@ starlette==0.52.1
 supervisor==4.3.0
 sympy==1.15.0.dev0+ppc64le1
 tokenizers==0.22.2
-torch==2.10.0+ppc64le1
+torch==2.11.0+ppc64le1
 tqdm==4.67.3
 transformers==4.57.6
 typer==0.24.1
@@ -117,9 +117,9 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.42.0
-vllm==0.18.1+cpuppc64le1
+vllm==0.21.0+cpuppc64le1
 watchfiles==0.21.0+ppc64le1
 websockets==16.0
 wrapt==2.1.2
-xgrammar==0.1.33+ppc64le1
+xgrammar===0.2.0
 yarl==1.23.0+ppc64le1

--- a/examples/Python3.12/vllm-example/requirements.txt
+++ b/examples/Python3.12/vllm-example/requirements.txt
@@ -16,7 +16,7 @@ cffi==2.0.0+ppc64le1
 charset_normalizer==3.4.6
 click==8.3.1
 cloudpickle==3.1.2+ppc64le1
-compressed-tensors==0.13.0
+compressed-tensors==0.15.0.1
 depyf==0.20.0
 dill==0.4.1+ppc64le1
 diskcache==5.6.3
@@ -55,7 +55,7 @@ loguru==0.7.3
 markdown-it-py==4.0.0
 mcp==1.26.0
 mdurl==0.1.2
-mistral_common==1.10.0
+mistral_common==1.11.3
 model-hosting-container-standards==0.1.14
 mpmath==1.3.0+ppc64le1
 msgspec==0.19.0+ppc64le2
@@ -64,10 +64,10 @@ networkx==3.6.1
 ninja==1.13.0
 numba==0.61.2+ppc64le3
 numpy==2.2.6+ppc64le1
-openai==1.99.1
+openai==2.0.0
 openai-harmony==0.0.8+ppc64le1
 opencv-python-headless==4.13.0.92+ppc64le1
-outlines_core==0.2.11+ppc64le1
+outlines_core==0.2.14+ppc64le1
 packaging==26.0
 partial-json-parser==0.2.1.1.post7
 prometheus-fastapi-instrumentator==7.1.0
@@ -109,7 +109,7 @@ starlette==0.52.1
 supervisor==4.3.0
 sympy==1.15.0.dev0+ppc64le1
 tokenizers==0.22.2
-torch==2.10.0+ppc64le1
+torch==2.11.0+ppc64le1
 tqdm==4.67.3
 transformers==4.57.6
 typer==0.24.1
@@ -117,9 +117,9 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.42.0
-vllm==0.18.1+cpuppc64le1
+vllm==0.21.0+cpuppc64le1
 watchfiles==0.21.0+ppc64le1
 websockets==16.0
 wrapt==2.1.2
-xgrammar==0.1.33+ppc64le1
+xgrammar===0.2.0
 yarl==1.23.0+ppc64le1


### PR DESCRIPTION
- Updated package versions for vllm==0.21.0+ppc64le1, outlines_core==0.2.14+ppc64le1 & torch== 2.11.0+ppc64le1
- Did not update transforms=5.1.0+ppc64le1 as vllm 0.21.0+cpuppc64le1 depends on transformers!=5.0.*, !=5.1.*, !=5.2.*, !=5.3.*, !=5.4.*, !=5.5.0 and >=4.56.0
- Updated openai==2.0.0 as vllm 0.21.0+cpuppc64le1 depends on openai>=2.0.0
- Updated compressed-tensors==0.15.0.1 as vllm 0.21.0+cpuppc64le1 depends on compressed-tensors==0.15.0.1
- xgrammar and afapache-tvn-ffi are built from source as vllm 0.21.0+cpuppc64le1 depends on xgrammar<1.0.0 and >=0.2.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
- Updated mistral_common==1.11.3, to resolve this conflict
```
ERROR: Cannot install mistral-common[image]==1.11.2, mistral-common[image]==1.11.3 and mistral_common==1.10.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested mistral_common==1.10.0
    mistral-common[image] 1.11.3 depends on mistral-common 1.11.3 (from https://files.pythonhosted.org/packages/7b/76/dbfdf9c59e2a4b0116587626a3768c2a3b2ba1758b5756743918c2337fdc/mistral_common-1.11.3-py3-none-any.whl (from https://pypi.org/simple/mistral-common/) (requires-python:<3.15,>=3.10.0))
    The user requested mistral_common==1.10.0
    mistral-common[image] 1.11.2 depends on mistral-common 1.11.2 (from https://files.pythonhosted.org/packages/47/f0/6a5d604b972e442b9d36c117d01788feddad099e4965699e3516ee6fefc3/mistral_common-1.11.2-py3-none-any.whl (from https://pypi.org/simple/mistral-common/) (requires-python:<3.15,>=3.10.0))

```