### PR TITLE
update: remove primp dependency from scikitlearn example requirements

### DIFF
--- a/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/install_test_example.sh
+++ b/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/install_test_example.sh
@@ -57,7 +57,7 @@ python3.11 -m venv .venv
 source .venv/bin/activate
 
 # Install Python dependencies
-pip install --prefer-binary --extra-index-url=https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
+pip install --prefer-binary --extra-index-url=https://wheels.developerfirst.ibm.com/ppc64le/linux-v2026.06.0 -r requirements.txt
 
 # Upgrade pip
 pip install --upgrade pip

--- a/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -30,7 +30,6 @@ ormsgpack==1.12.2+ppc64le1
 packaging==25.0
 pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
-primp==0.15.0+ppc64le1
 protobuf==4.25.3+ppc64le1
 psutil==7.0.0+ppc64le1
 pulsar-client==3.8.0+ppc64le1

--- a/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/install_test_example.sh
+++ b/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/install_test_example.sh
@@ -57,7 +57,7 @@ python3.12 -m venv .venv
 source .venv/bin/activate
 
 # Install Python dependencies
-pip install --prefer-binary --extra-index-url=https://wheels.developerfirst.ibm.com/ppc64le/linux -r requirements.txt
+pip install --prefer-binary --extra-index-url=https://wheels.developerfirst.ibm.com/ppc64le/linux-v2026.06.0 -r requirements.txt
 
 # Upgrade pip
 pip install --upgrade pip

--- a/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -30,7 +30,6 @@ ormsgpack==1.12.2+ppc64le1
 packaging==25.0
 pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
-primp==0.15.0+ppc64le1
 protobuf==4.25.8+ppc64le1
 psutil==7.1.3+ppc64le1
 pulsar-client==3.8.0+ppc64le1


### PR DESCRIPTION
- Removed the **primp==0.15.0+ppc64le1** dependency from the **scikitlearn-ibmcossdk-jwt-example** requirements.
- Updated the example index links to use the examples testing repository.
- Verified that the example works after the dependency removal.