### PR TITLE
docs: remove LD_LIBRARY_PATH guidance from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,7 @@ devpi use https://wheels.developerfirst.ibm.com/ppc64le/linux
 devpi list
 ```
 
-💡 **Tip**: You no longer need to set LD_LIBRARY_PATH when using Power manylinux wheels. Native dependencies are bundled automatically, so packages install cleanly and work consistently across Linux distributions such as SLES, Ubuntu, and RHEL.
-
-📝 **Note**: Legacy wheels that do not support manylinux still require LD_LIBRARY_PATH to be set for correct execution.
-
-### Troubleshooting Tips 
+### Troubleshooting Tips
 
 - If a package fails to install, try forcing binary wheels and disabling cache:
 
@@ -115,20 +111,6 @@ devpi list
   ```
 
 - If a package is missing, request it via [IBM Power ISV ecosystem enablement form](https://www.ibm.com/power/resources/isv/enablement-request/)
-
-- Most Python packages (e.g., TensorFlow, PyTorch) ship as manylinux wheels, which include all required shared libraries so normally, you don't need to set LD_LIBRARY_PATH. If you installed a non-manylinux wheel, you might see errors like: 
-
-  ```
-  ImportError: libXYZ.so: cannot open shared object file
-  ```
-
-  Set the path to your native libraries:
-
-  ```bash
-  export LD_LIBRARY_PATH=/path/to/libs:$LD_LIBRARY_PATH
-  ```
-
-  Use `ldd $(which python)` or `ldd <binary>` to check for missing .so files.
 
 ### Best Practices
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -74,6 +74,22 @@ mv /opt/app-root/lib64/python3.12/site-packages/milvus_lite/lib/libgcc_s.so.1 \
    /opt/app-root/lib64/python3.12/site-packages/milvus_lite/lib/libgcc_s.so.1.disabled
 ```
 
+## 🗑️ Removed
+
+### `LD_LIBRARY_PATH` Requirement
+
+Previously, users installing non-manylinux wheels had to manually set `LD_LIBRARY_PATH` to point to native shared libraries, to avoid runtime errors such as:
+
+```
+ImportError: libXYZ.so: cannot open shared object file
+```
+
+All wheels provided in this repository are **manylinux-compliant** and bundle their required native dependencies directly. This means:
+
+- No manual `LD_LIBRARY_PATH` configuration is needed.
+- Packages install cleanly and run consistently across all supported Linux distributions (RHEL, Ubuntu, SLES).
+- The related tip, note, and troubleshooting guidance for `LD_LIBRARY_PATH` have been removed from the README accordingly.
+
 ## 🚫 Deprecation Notice: Python 3.9 Support
 Support for Python 3.9 has been removed starting with this release.
 If you’re still using Python 3.9, please plan to upgrade to Python 3.10 or later to ensure compatibility with future updates.


### PR DESCRIPTION
README.md - removed LD_LIBRARY guidance.
ReleaseNotes - mention removal of LD_LIBRARY guidance