### PR TITLE
Updated v7 release notes for packages without suffix

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -50,7 +50,7 @@ Detailed package license information and CVE disclosures are available at
 | **torchvision** | 0.24.1 | 3.11, 3.12, 3.13, 3.14 | 2.9.x |
 | **torchvision** | 0.25.0 | 3.11, 3.14 | 2.9.0 |
 | **torchtext** | 0.15.2 | 3.12 | 2.8.0 |
-| **torchtext** | 0.16.2 | 3.120, 3.11 | 2.8.0 |
+| **torchtext** | 0.16.2 | 3.10, 3.11 | 2.8.0 |
 | **torchtext** | 0.18.0 | 3.10, 3.11, 3.12, 3.13 | 2.8.0 |
 | **torchaudio** | 2.6.0 | 3.11, 3.12 | 2.6.0 |
 | **torchaudio** | 2.7.1 | 3.10, 3.11, 3.12, 3.13 | 2.7.1 | 
@@ -58,7 +58,7 @@ Detailed package license information and CVE disclosures are available at
 | **torchaudio** | 2.9.0 | 3.10, 3.11, 3.12, 3.13, 3.14 | 2.9.0 | 
 | **torchaudio** | 2.9.1 | 3.10, 3.11, 3.12, 3.13, 3.14 | 2.9.1 | 
 
-For complete version compatiblity between PyTorch and domain libraries, pls see - [PyTorch - Domain libraries version compatibility matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions)
+For complete version compatibility information between PyTorch and its domain libraries, see the - [PyTorch - Domain libraries version compatibility matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions)
  
 ### Numpy compatibility
 
@@ -77,7 +77,7 @@ The following packages require **NumPy 1.26.4** and are not compatible with NumP
 
 ### setuptools compatibility
 
-The following packages require **setuptools < 81**. 
+The following packages require **setuptools < 81** and may not function correctly with newer setuptools versions.
 - milvus-lite
 - paddlepaddle
 - AWX 24.6.1
@@ -101,7 +101,7 @@ Compilation requires the following development tools:
 
 **Affected packages:**
 - ansible_rulebook 1.1.*
-- autovizwidget v0.22.0
+- autovizwidget 0.22.0
 - cforge v1.0.0b4
 - cutadapt 5.1
 - lightgbm 3.3.2
@@ -109,8 +109,8 @@ Compilation requires the following development tools:
 - orange3 v3.38.1
 - poetry 1.8.*
 - sparkmagic 0.20.0
-- tensorflow v2.14.1
-- tensorflow-text v2.14.0
+- tensorflow 2.14.1
+- tensorflow-text 2.14.0
 - uvtools
 - apache-airflow (requires Rust and Cargo)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -23,13 +23,22 @@ Additionally, wheels without local version identifiers (suffixes) are now provid
     - 6 new packages -  jq, paddlepaddle, networkx, mistral_common, setools and srsly.
     - Packaging fixes in 17 native library wheels.
     - TensorFlow v2.14.1 and its dependencies for UBI 8.10
-
+ 
 ## Package Licenses and CVE Details
 
 Detailed package license information and CVE disclosures are available at 
 [Package Licenses and CVE Details](https://github.com/ppc64le/pyeco/blob/main/DevpiWheelsIndex.md)
 
+## Package Prerequisites
+- PyJNIus requires JDK to be installed. 
+- ruamel.yaml is required for ruamel_yaml_clib.
+- httpx is required for httpx_sse.
+- tensorflow-io-gcs-filesystem requires tensorflow.
+- TensorFlow v2.18.1 is compatible with flatbuffers v25.2.10.
+
 ## Package Version compatiblity
+
+### PyTorch compatibility
 
 | Package | Version | Python Versions | Compatible Torch Version | 
 |---------|---------|-----------------|-------------------------|
@@ -50,6 +59,7 @@ Detailed package license information and CVE disclosures are available at
 For complete version compatiblity between PyTorch and domain libraries, pls see - [PyTorch - Domain libraries version compatibility matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions)
  
 ### Numpy compatibility
+
 The following packages require **NumPy 1.26.4** and are not compatible with NumPy 2.x.
 
 - bottleneck 1.3.5
@@ -71,13 +81,6 @@ The following packages require **setuptools < 81**.
 - AWX 24.6.1
 - setools
 - xgboost
-
-## Package Prerequisites
-- PyJNIus requires JDK to be installed. 
-- ruamel.yaml is required for ruamel_yaml_clib.
-- httpx is required for httpx_sse.
-- tensorflow-io-gcs-filesystem requires tensorflow.
-- TensorFlow v2.18.1 is compatible with flatbuffers v25.2.10.
 
 ## ⚠️ Known Issues
 ### Platform Support 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -32,16 +32,22 @@ Detailed package license information and CVE disclosures are available at
 
 | Package | Version | Python Versions | Compatible Torch Version | 
 |---------|---------|-----------------|-------------------------|
-| **torchvision** | 0.22.1+ppc64le1 | 3.11, 3.13 | 2.6.0 | 
-| **torchvision** | 0.24.0+ppc64le1 | 3.11 | 2.9.0 |
-| **torchvision** | 0.24.1+ppc64le1 | 3.10, 3.12 | 2.9.x |
-| **torchvision** | 0.24.1+ppc64le2 | 3.11, 3.12, 3.13, 3.14 | 2.9.x |
-| **torchvision** | 0.25.0+ppc64le1 | 3.11, 3.14 | 2.9.0 |
-| **torchtext** | 0.18.0+ppc64le1 | 3.12 | 2.8.0 |
-| **torchaudio** | 2.7.1+ppc64le1 | 3.10, 3.11, 3.12, 3.13 | 2.7.1 | 
-| **torchaudio** | 2.9.0+ppc64le1 | 3.10, 3.11, 3.12, 3.13, 3.14 | 2.9.0 | 
-| **torchaudio** | 2.9.1+ppc64le2 | 3.10, 3.12, 3.13, 3.14 | 2.9.1 | 
-| **torchaudio** | 2.9.1+ppc64le3 | 3.11 | 2.9.1 | 
+| **torchvision** | 0.22.1 | 3.11, 3.13 | 2.6.0 | 
+| **torchvision** | 0.24.0 | 3.11 | 2.9.0 |
+| **torchvision** | 0.24.1 | 3.10, 3.12 | 2.9.x |
+| **torchvision** | 0.24.1 | 3.11, 3.12, 3.13, 3.14 | 2.9.x |
+| **torchvision** | 0.25.0 | 3.11, 3.14 | 2.9.0 |
+| **torchtext** | 0.15.2 | 3.12 | 2.8.0 |
+| **torchtext** | 0.16.2 | 3.120, 3.11 | 2.8.0 |
+| **torchtext** | 0.18.0 | 3.10, 3.11, 3.12, 3.13 | 2.8.0 |
+| **torchaudio** | 2.6.0 | 3.11, 3.12 | 2.6.0 |
+| **torchaudio** | 2.7.1 | 3.10, 3.11, 3.12, 3.13 | 2.7.1 | 
+| **torchaudio** | 2.8.0 | 3.12 | 2.8.0 |
+| **torchaudio** | 2.9.0 | 3.10, 3.11, 3.12, 3.13, 3.14 | 2.9.0 | 
+| **torchaudio** | 2.9.1 | 3.10, 3.11, 3.12, 3.13, 3.14 | 2.9.1 | 
+
+For version compatiblity between PyTorch and domain libraries - [PyTorch - Domain libraries version compatibility matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions)
+ 
 
 ## Prerequisites
 - PyJNIus requires JDK to be installed.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -32,10 +32,10 @@ Detailed package license information and CVE disclosures are available at
 [Package Licenses and CVE Details](https://github.com/ppc64le/pyeco/blob/main/DevpiWheelsIndex.md)
 
 ## Package Prerequisites
-- PyJNIus requires JDK to be installed. 
+- JDK is required for PyJNIus. 
 - ruamel.yaml is required for ruamel_yaml_clib.
 - httpx is required for httpx_sse.
-- tensorflow-io-gcs-filesystem requires tensorflow.
+- TensorFlow is required for tensorflow-io-gcs-filesystem.
 - TensorFlow v2.18.1 is compatible with flatbuffers v25.2.10.
 
 ## Package Version compatiblity

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,7 +5,9 @@
 ## Overview
 
 This release includes updates to 50+ Python packages across multiple Python versions (3.10 to 3.14), focusing on AI/ML frameworks, data processing libraries, web frameworks, and infrastructure tools.
+
 Additionally, wheels without local version identifiers (suffixes) are now provided for uv compatibility. These wheels are available alongside the corresponding versions that include local version suffixes.
+
 ---
  
 ## Supported Platforms

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,6 +5,7 @@
 ## Overview
 
 This release includes updates to 50+ Python packages across multiple Python versions (3.10 to 3.14), focusing on AI/ML frameworks, data processing libraries, web frameworks, and infrastructure tools.
+Additionally, wheels without local version identifiers (suffixes) are now provided for uv compatibility. These wheels are available alongside the corresponding versions that include local version suffixes.
 ---
  
 ## Supported Platforms
@@ -77,18 +78,10 @@ The following packages require **setuptools < 81**.
 - httpx is required for httpx_sse.
 - tensorflow-io-gcs-filesystem requires tensorflow.
 - TensorFlow v2.18.1 is compatible with flatbuffers v25.2.10.
-- 
-
-
 
 ## ⚠️ Known Issues
 ### Platform Support 
 - Ollama is not supported on Power9.
-
-### Python Version Support 
-- aesera v2.9.4 and flatbuffers v2.0.0 do not support Python v3.12.
-- ansible-core v2.18.6: Python 3.10 is not supported.
-- cforge v1.0.0b4: Supports Python ≥ 3.11.
 
 ### Missing Pre-built Wheels for Some Dependencies
 Some packages in this release do not have pre-built wheels available for certain dependencies.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -36,7 +36,8 @@ Detailed package license information and CVE disclosures are available at
 - ruamel.yaml is required for ruamel_yaml_clib.
 - httpx is required for httpx_sse.
 - TensorFlow is required for tensorflow-io-gcs-filesystem.
-- TensorFlow v2.18.1 is compatible with flatbuffers v25.2.10.
+- TensorFlow 2.18.1 is compatible with flatbuffers 25.2.10.
+- iminuit 2.28.0 depends on packaging, which must be installed explicitly.
 
 ## Package Version compatiblity
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -46,26 +46,75 @@ Detailed package license information and CVE disclosures are available at
 | **torchaudio** | 2.9.0 | 3.10, 3.11, 3.12, 3.13, 3.14 | 2.9.0 | 
 | **torchaudio** | 2.9.1 | 3.10, 3.11, 3.12, 3.13, 3.14 | 2.9.1 | 
 
-For version compatiblity between PyTorch and domain libraries - [PyTorch - Domain libraries version compatibility matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions)
+For complete version compatiblity between PyTorch and domain libraries, pls see - [PyTorch - Domain libraries version compatibility matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions)
  
+### Numpy compatibility
+The following packages require **NumPy 1.26.4** and are not compatible with NumPy 2.x.
 
-## Prerequisites
-- PyJNIus requires JDK to be installed.
+- bottleneck 1.3.5
+- h5py 3.7.0, 3.10.0
+- ml-dtypes 0.1.0, 0.2.0
+- matplotlib 3.7.1
+- numexpr 2.8.4, 2.8.7
+- pandas 1.5.3, 2.1.1
+- pyarrow 11.0.0
+- scikit-image 0.19.3, 0.20.0, 0.22.0
+- PyWavelets 1.4.1
+- pyclaw 5.12.0
+
+### setuptools compatibility
+
+The following packages require **setuptools < 81**. 
+- milvus-lite
+- paddlepaddle
+- AWX 24.6.1
+- setools
+- xgboost
+
+## Package Prerequisites
+- PyJNIus requires JDK to be installed. 
 - ruamel.yaml is required for ruamel_yaml_clib.
 - httpx is required for httpx_sse.
-- AWX 24.6.1 and setools require setuptools < 81.
-- paddlepaddle requires setuptools.
-- h5py v3.10.0 is compatible with numpy==1.26.4.
-- ml_dtypes requires numpy < 2.
 - tensorflow-io-gcs-filesystem requires tensorflow.
 - TensorFlow v2.18.1 is compatible with flatbuffers v25.2.10.
+- 
 
-## Known Issues
+
+
+## ⚠️ Known Issues
+### Platform Support 
 - Ollama is not supported on Power9.
-- fire < 0.7.0 does not support Python 3.13/3.14.
-- cforge v1.0.0b4 requires zeroconf>=0.148.0. As prebuilt wheel is not available, this dependency must be compiled from source and requires development tools. Additionally, cforge does not support Python 3.10/3.14.
-- macs requires cykhash<3.0,>=2.0 and hmmlearn>=0.3; due to missing prebuilt wheels, these dependencies must be built from source using development tools.
-- iminuit v2.28.0 depends on packaging, which must be installed explicitly.
+
+### Python Version Support 
+- aesera v2.9.4 and flatbuffers v2.0.0 do not support Python v3.12.
+- ansible-core v2.18.6: Python 3.10 is not supported.
+- cforge v1.0.0b4: Supports Python ≥ 3.11.
+
+### Missing Pre-built Wheels for Some Dependencies
+Some packages in this release do not have pre-built wheels available for certain dependencies.
+As a result, these dependencies must be compiled from source during installation.
+
+**Requirements:**
+Compilation requires the following development tools:
+- `gcc`
+- `g++`
+- Python development headers
+- Rust and Cargo (required for apache-airflow)
+
+**Affected packages:**
+- ansible_rulebook 1.1.*
+- autovizwidget v0.22.0
+- cforge v1.0.0b4
+- cutadapt 5.1
+- lightgbm 3.3.2
+- macs
+- orange3 v3.38.1
+- poetry 1.8.*
+- sparkmagic 0.20.0
+- tensorflow v2.14.1
+- tensorflow-text v2.14.0
+- uvtools
+- apache-airflow (requires Rust and Cargo)
 
 ## 🔧 Troubleshooting
 


### PR DESCRIPTION
- Added a point highlighting that packages without suffix are being added. 
- Updated section on pytorch compatibility
- Added sub-section on numpy and setuptools compatibility.
- Upated Known issues section
- Skipping Python version compatibility section for packages as it is as per upstream python version compatibility. 