### PR TITLE
Removed primp dependency from scikitlearn example requirements.txt for main branch

### DIFF
--- a/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -30,7 +30,6 @@ ormsgpack==1.12.2+ppc64le1
 packaging==25.0
 pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
-primp==0.15.0+ppc64le1
 protobuf==4.25.3+ppc64le1
 psutil==7.2.2+ppc64le1
 pulsar-client==3.8.0+ppc64le1

--- a/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -30,7 +30,6 @@ ormsgpack==1.12.2+ppc64le1
 packaging==25.0
 pandas==3.0.3+ppc64le1
 pillow==12.2.0+ppc64le1
-primp==0.15.0+ppc64le1
 protobuf==4.25.8+ppc64le1
 psutil==7.2.2+ppc64le1
 pulsar-client==3.8.0+ppc64le1


### PR DESCRIPTION
- Removed the primp==0.15.0+ppc64le1 dependency from the scikitlearn-ibmcossdk-jwt-example requirements.
- Tested the example, it works after removing the dependency.
- Results: 
[sles_Python3.11_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30902872/sles_Python3.11_scikitlearn-ibmcossdk-jwt-example.log)
[sles_Python3.12_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30902873/sles_Python3.12_scikitlearn-ibmcossdk-jwt-example.log)
[ubi9_Python3.11_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30902875/ubi9_Python3.11_scikitlearn-ibmcossdk-jwt-example.log)
[ubi9_Python3.12_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30902876/ubi9_Python3.12_scikitlearn-ibmcossdk-jwt-example.log)
[ubuntu_Python3.11_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30902877/ubuntu_Python3.11_scikitlearn-ibmcossdk-jwt-example.log)
[ubuntu_Python3.12_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30902879/ubuntu_Python3.12_scikitlearn-ibmcossdk-jwt-example.log)
