### PR TITLE
Removed primp dependency from scikitlearn example requirements for v2026.03.31 branch

### DIFF
--- a/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.11/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -30,7 +30,6 @@ ormsgpack==1.9.1+ppc64le1
 packaging==25.0
 pandas==2.3.2+ppc64le1
 pillow==11.2.1+ppc64le1
-primp==0.15.0+ppc64le1
 protobuf==4.25.3+ppc64le1
 psutil==7.0.0+ppc64le1
 pulsar-client==3.8.0+ppc64le1

--- a/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
+++ b/examples/Python3.12/scikitlearn-ibmcossdk-jwt-example/requirements.txt
@@ -30,7 +30,6 @@ ormsgpack==1.9.1+ppc64le1
 packaging==25.0
 pandas==2.3.2+ppc64le1
 pillow==12.1.1+ppc64le1
-primp==0.15.0+ppc64le1
 protobuf==4.25.8+ppc64le1
 psutil==7.0.0+ppc64le1
 pulsar-client==3.8.0+ppc64le1


### PR DESCRIPTION
 Removed the primp==0.15.0+ppc64le1 dependency from the scikitlearn-ibmcossdk-jwt-example requirements.
- Tested the example, it works after removing the dependency.
- Results: 
[sles_Python3.11_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30904078/sles_Python3.11_scikitlearn-ibmcossdk-jwt-example.log)
[sles_Python3.12_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30904080/sles_Python3.12_scikitlearn-ibmcossdk-jwt-example.log)
[ubi9_Python3.11_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30904081/ubi9_Python3.11_scikitlearn-ibmcossdk-jwt-example.log)
[ubi9_Python3.12_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30904084/ubi9_Python3.12_scikitlearn-ibmcossdk-jwt-example.log)
[ubuntu_Python3.11_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30904085/ubuntu_Python3.11_scikitlearn-ibmcossdk-jwt-example.log)
[ubuntu_Python3.12_scikitlearn-ibmcossdk-jwt-example.log](https://github.com/user-attachments/files/30904086/ubuntu_Python3.12_scikitlearn-ibmcossdk-jwt-example.log)
