### PR TITLE
Update orjson version in requirements.txt for langchain-example

### DIFF
--- a/examples/Python3.11/langchain-example/requirements.txt
+++ b/examples/Python3.11/langchain-example/requirements.txt
@@ -14,7 +14,7 @@ langchain-core==1.2.10
 langchain-text-splitters==0.3.11
 langsmith==0.7.10
 numpy==2.4.6
-orjson==3.11.7
+orjson==3.12.0
 packaging==25.0
 pydantic==2.12.5
 pydantic_core==2.41.5

--- a/examples/Python3.12/langchain-example/requirements.txt
+++ b/examples/Python3.12/langchain-example/requirements.txt
@@ -14,7 +14,7 @@ langchain-core==1.2.10
 langchain-text-splitters==0.3.11
 langsmith==0.7.10
 numpy==2.5.1
-orjson==3.11.7
+orjson==3.12.0
 packaging==25.0
 pydantic==2.12.5
 pydantic_core==2.41.5


### PR DESCRIPTION
- Updated orjson version in requirements.txt for langchain-example in Python3.11 and Python3.12.
- Example testing was successful for RHEL, UBUNTU and  SLES.
- Test logs:
[sles_Python3.11_langchain-example.log](https://github.com/user-attachments/files/31771110/sles_Python3.11_langchain-example.log)
[sles_Python3.12_langchain-example.log](https://github.com/user-attachments/files/31771116/sles_Python3.12_langchain-example.log)
[ubi9_Python3.11_langchain-example.log](https://github.com/user-attachments/files/31771117/ubi9_Python3.11_langchain-example.log)
[ubi9_Python3.12_langchain-example.log](https://github.com/user-attachments/files/31771118/ubi9_Python3.12_langchain-example.log)
[ubuntu_Python3.11_langchain-example.log](https://github.com/user-attachments/files/31771119/ubuntu_Python3.11_langchain-example.log)
[ubuntu_Python3.12_langchain-example.log](https://github.com/user-attachments/files/31771120/ubuntu_Python3.12_langchain-example.log)
